### PR TITLE
Scene synch

### DIFF
--- a/Adapters/Photon Unity Networking/PUNEventCascader.cs
+++ b/Adapters/Photon Unity Networking/PUNEventCascader.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ASL.Adapters.PUN
+{
+    public static class PUNEventCascader
+    {
+        public static void Join()
+        {
+            RaiseEventOptions options = new RaiseEventOptions();
+            options.Receivers = ReceiverGroup.All;
+            PhotonNetwork.RaiseEvent(UWBNetworkingPackage.ASLEventCode.EV_JOIN, null, true, options);
+        }
+    }
+}

--- a/Adapters/Photon Unity Networking/PUNEventCascader.cs.meta
+++ b/Adapters/Photon Unity Networking/PUNEventCascader.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2ac051690f628b64da48e55db53e586c
+timeCreated: 1509148909
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UWBNetworkingPackage/Scripts/ASLEventCode.cs
+++ b/UWBNetworkingPackage/Scripts/ASLEventCode.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UWBNetworkingPackage
+{
+    public static class ASLEventCode
+    {
+        public const byte EV_INSTANTIATE = 99;
+        public const byte EV_DESTROYOBJECT = 98;
+        public const byte EV_SYNCSCENE = 97;
+        public const byte EV_JOIN = 55;
+    }
+}

--- a/UWBNetworkingPackage/Scripts/ASLEventCode.cs.meta
+++ b/UWBNetworkingPackage/Scripts/ASLEventCode.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1cb929ccc6633014a8d51c07b90c57e7
+timeCreated: 1509149345
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UWBNetworkingPackage/Scripts/Launcher.cs
+++ b/UWBNetworkingPackage/Scripts/Launcher.cs
@@ -51,8 +51,8 @@ namespace UWBNetworkingPackage
         /// </summary>
         public virtual void Awake()
         {
-            PhotonNetwork.logLevel = PhotonLogLevel.Full;
-            //PhotonNetwork.logLevel = PhotonLogLevel.ErrorsOnly;
+            //PhotonNetwork.logLevel = PhotonLogLevel.Full;
+            PhotonNetwork.logLevel = PhotonLogLevel.ErrorsOnly;
             PhotonNetwork.autoJoinLobby = false;
             PhotonNetwork.automaticallySyncScene = false;
             PhotonNetwork.MaxResendsBeforeDisconnect = 5;

--- a/UWBNetworkingPackage/Scripts/Launcher.cs
+++ b/UWBNetworkingPackage/Scripts/Launcher.cs
@@ -51,8 +51,8 @@ namespace UWBNetworkingPackage
         /// </summary>
         public virtual void Awake()
         {
-            //PhotonNetwork.logLevel = PhotonLogLevel.Full;
-            PhotonNetwork.logLevel = PhotonLogLevel.ErrorsOnly;
+            PhotonNetwork.logLevel = PhotonLogLevel.Full;
+            //PhotonNetwork.logLevel = PhotonLogLevel.ErrorsOnly;
             PhotonNetwork.autoJoinLobby = false;
             PhotonNetwork.automaticallySyncScene = false;
             PhotonNetwork.MaxResendsBeforeDisconnect = 5;
@@ -124,6 +124,13 @@ namespace UWBNetworkingPackage
             {
                 PhotonNetwork.ConnectUsingSettings(_version);
             }
+        }
+
+        public override void OnJoinedRoom()
+        {
+            base.OnJoinedRoom();
+
+            ASL.Adapters.PUN.PUNEventCascader.Join();
         }
 
         [PunRPC]

--- a/UWBNetworkingPackage/Scripts/ObjectInfoDatabase.cs
+++ b/UWBNetworkingPackage/Scripts/ObjectInfoDatabase.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UWBNetworkingPackage
+{
+    public static class ObjectInfoDatabase
+    {
+        public static Dictionary<string, ObjectInfoMetadata> ObjectDatabase;
+        private static System.DateTime lastUpdate;
+
+        static ObjectInfoDatabase()
+        {
+            ObjectDatabase = new Dictionary<string, ObjectInfoMetadata>();
+            lastUpdate = System.DateTime.MinValue;
+        }
+
+        public static void Add(GameObject go)
+        {
+            string objectName = go.name;
+
+            int ownerID = 0;
+            PhotonView view = go.GetComponent<PhotonView>();
+            if(view != null)
+            {
+                ownerID = view.ownerId;
+            }
+            ObjectInfoMetadata objectInfo = new ObjectInfoMetadata(go, ownerID);
+
+            if (ObjectDatabase.ContainsKey(objectName))
+            {
+                ObjectDatabase.Remove(objectName);
+            }
+            ObjectDatabase.Add(objectName, objectInfo);
+
+            lastUpdate = System.DateTime.Now;
+        }
+
+        public static void Remove(GameObject go)
+        {
+            if (ObjectDatabase.ContainsKey(go.name))
+            {
+                ObjectDatabase.Remove(go.name);
+                lastUpdate = System.DateTime.Now;
+            }
+        }
+
+        public static ObjectInfoMetadata Get(string objectName)
+        {
+            if (ObjectDatabase.ContainsKey(objectName))
+            {
+                return ObjectDatabase[objectName];
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public static bool Contains(string objectName)
+        {
+            return ObjectDatabase.ContainsKey(objectName);
+        }
+
+        public static System.DateTime UpdateTime
+        {
+            get
+            {
+                return lastUpdate;
+            }
+        }
+
+        public static bool Empty
+        {
+            get
+            {
+                return ObjectDatabase.Count < 1;
+            }
+        }
+
+        public static int Count
+        {
+            get
+            {
+                return ObjectDatabase.Count;
+            }
+        }
+    }
+}

--- a/UWBNetworkingPackage/Scripts/ObjectInfoDatabase.cs.meta
+++ b/UWBNetworkingPackage/Scripts/ObjectInfoDatabase.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f629816aa014ced43b8d0b14870cb845
+timeCreated: 1509151870
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UWBNetworkingPackage/Scripts/ObjectInfoMetadata.cs
+++ b/UWBNetworkingPackage/Scripts/ObjectInfoMetadata.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UWBNetworkingPackage
+{
+    public class ObjectInfoMetadata
+    {
+        public string ObjectName;
+        public UnityEngine.Vector3 Position;
+        public UnityEngine.Quaternion Rotation;
+        public UnityEngine.Bounds BoundingBox;
+
+        // PUN Stuff
+        public int OwnerID;
+
+        public ObjectInfoMetadata(GameObject go, int ownerID)
+        {
+            this.ObjectName = go.name;
+            this.Position = go.transform.position;
+            this.Rotation = go.transform.rotation;
+            if (go.GetComponent<MeshFilter>() != null)
+            {
+                Mesh mesh = go.GetComponent<MeshFilter>().sharedMesh;
+                if (mesh == null)
+                {
+                    mesh = go.GetComponent<MeshFilter>().mesh;
+                }
+
+                if (mesh != null)
+                {
+                    this.BoundingBox = mesh.bounds;
+                }
+            }
+            else
+            {
+                this.BoundingBox = new Bounds();
+            }
+
+            this.OwnerID = (ownerID < 1) ? 0 : ownerID; // associate object with scene
+        }
+    }
+}

--- a/UWBNetworkingPackage/Scripts/ObjectInfoMetadata.cs.meta
+++ b/UWBNetworkingPackage/Scripts/ObjectInfoMetadata.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 33765489e5956af4d8d8841090644678
+timeCreated: 1509151870
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UWBNetworkingPackage/Scripts/ObjectInstantiationDatabase.cs
+++ b/UWBNetworkingPackage/Scripts/ObjectInstantiationDatabase.cs
@@ -1,0 +1,196 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UWBNetworkingPackage
+{
+    public static class ObjectInstantiationDatabase
+    {
+        public static Dictionary<string, List<KeyValuePair<ObjectInstantiationMetadata, GameObject>>> ObjectDatabase;
+        public static Dictionary<GameObject, string> PrefabLookupTable;
+        private static System.DateTime lastUpdate;
+
+        static ObjectInstantiationDatabase()
+        {
+            //ObjectDatabase = new Dictionary<string, ObjectInstantiationMetadata>();
+            ObjectDatabase = new Dictionary<string, List<KeyValuePair<ObjectInstantiationMetadata, GameObject>>>();
+            PrefabLookupTable = new Dictionary<GameObject, string>();
+            lastUpdate = System.DateTime.MinValue;
+        }
+
+        public static void Add(string prefabName, GameObject go)
+        {
+            string objectName = go.name;
+
+            int ownerID = 0;
+            PhotonView view = go.GetComponent<PhotonView>();
+            if (view != null)
+            {
+                ownerID = view.ownerId;
+            }
+            ObjectInfoMetadata objectInfo = new ObjectInfoMetadata(go, ownerID);
+
+            System.DateTime currentTime = System.DateTime.Now;
+
+            ObjectInstantiationMetadata instantiationMetadata = new ObjectInstantiationMetadata(objectInfo, prefabName, currentTime);
+            
+            if (!ObjectDatabase.ContainsKey(objectName))
+            {
+                ObjectDatabase.Add(objectName, new List<KeyValuePair<ObjectInstantiationMetadata, GameObject>>());
+            }
+
+            ObjectDatabase[objectName].Add(new KeyValuePair<ObjectInstantiationMetadata, GameObject>(instantiationMetadata, go));
+            PrefabLookupTable.Add(go, prefabName);
+
+            lastUpdate = System.DateTime.Now;
+        }
+
+        public static bool Remove(GameObject go)
+        {
+            if(go == null)
+            {
+                return false;
+            }
+            else if (ObjectDatabase.ContainsKey(go.name))
+            {
+                bool removed = false;
+
+                string objectName = go.name;
+                List<KeyValuePair<ObjectInstantiationMetadata, GameObject>> valuePairList = ObjectDatabase[objectName];
+                foreach(KeyValuePair<ObjectInstantiationMetadata, GameObject> valuePair in valuePairList)
+                {
+                    if (valuePair.Value.Equals(go))
+                    {
+                        ObjectDatabase[objectName].Remove(valuePair);
+                        removed = true;
+                        if (PrefabLookupTable.ContainsKey(go))
+                        {
+                            PrefabLookupTable.Remove(go);
+                        }
+                        lastUpdate = System.DateTime.Now;
+                        break;
+                    }
+                }
+
+                return removed;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        public static bool Remove(GameObject go, string goName)
+        {
+            if (string.IsNullOrEmpty(goName))
+            {
+                return false;
+            }
+            else if(go != null)
+            {
+                return Remove(go);
+            }
+            else if (ObjectDatabase.ContainsKey(goName))
+            {
+                bool removed = false;
+                List<KeyValuePair<ObjectInstantiationMetadata, GameObject>> valuePairList = ObjectDatabase[goName];
+                foreach (KeyValuePair<ObjectInstantiationMetadata, GameObject> valuePair in valuePairList)
+                {
+                    if (valuePair.Value == null)
+                    {
+                        ObjectDatabase[goName].Remove(valuePair);
+                        removed = true;
+                        lastUpdate = System.DateTime.Now;
+                    }
+                }
+
+                if (PrefabLookupTable.ContainsKey(null))
+                {
+                    PrefabLookupTable.Remove(null);
+                }
+
+                return removed;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        public static ObjectInstantiationMetadata Get(GameObject go)
+        {
+            if (go != null)
+            {
+                string objectDatabaseKey = go.name;
+                if (ObjectDatabase.ContainsKey(objectDatabaseKey))
+                {
+                    List<KeyValuePair<ObjectInstantiationMetadata, GameObject>> pairList = ObjectDatabase[objectDatabaseKey];
+                    foreach (KeyValuePair<ObjectInstantiationMetadata, GameObject> pair in pairList)
+                    {
+                        if (pair.Value.Equals(go))
+                        {
+                            return pair.Key;
+                        }
+                    }
+                }
+
+                UnityEngine.Debug.LogError("Object Instantiation metadata not found!");
+                return null;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public static List<ObjectInstantiationMetadata> GetAll(string objectName)
+        {
+            List<ObjectInstantiationMetadata> metadataList = new List<ObjectInstantiationMetadata>();
+            if (ObjectDatabase.ContainsKey(objectName))
+            {
+                List<KeyValuePair<ObjectInstantiationMetadata, GameObject>> pairList = ObjectDatabase[objectName];
+                foreach(KeyValuePair<ObjectInstantiationMetadata, GameObject> pair in pairList)
+                {
+                    metadataList.Add(pair.Key);
+                }
+            }
+
+            return metadataList;
+        }
+
+        public static string GetPrefabName(GameObject go)
+        {
+            if(go != null)
+            {
+                if (PrefabLookupTable.ContainsKey(go))
+                {
+                    return PrefabLookupTable[go];
+                }
+            }
+
+            UnityEngine.Debug.LogError("GameObject prefab name not found.");
+            return null;
+        }
+
+        public static bool Contains(string objectName)
+        {
+            return ObjectDatabase.ContainsKey(objectName);
+        }
+
+        public static System.DateTime UpdateTime
+        {
+            get
+            {
+                return lastUpdate;
+            }
+        }
+
+        public static bool Empty
+        {
+            get
+            {
+                return ObjectDatabase.Count < 1;
+            }
+        }
+    }
+}

--- a/UWBNetworkingPackage/Scripts/ObjectInstantiationDatabase.cs.meta
+++ b/UWBNetworkingPackage/Scripts/ObjectInstantiationDatabase.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: fae9ca6952a7ed3438ec6b9222f76905
+timeCreated: 1509151723
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UWBNetworkingPackage/Scripts/ObjectInstantiationMetadata.cs
+++ b/UWBNetworkingPackage/Scripts/ObjectInstantiationMetadata.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UWBNetworkingPackage
+{
+    public class ObjectInstantiationMetadata
+    {
+        public ObjectInfoMetadata ObjectInfo;
+        public string PrefabName;
+        public System.DateTime InstantiationTime;
+
+        public ObjectInstantiationMetadata(ObjectInfoMetadata objectInfo, string prefabName, System.DateTime currentTime)
+        {
+            this.ObjectInfo = objectInfo;
+            this.PrefabName = prefabName;
+            this.InstantiationTime = currentTime;
+        }
+    }
+}

--- a/UWBNetworkingPackage/Scripts/ObjectInstantiationMetadata.cs.meta
+++ b/UWBNetworkingPackage/Scripts/ObjectInstantiationMetadata.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9c22b5ba39fcf894787c1f5aad4300b2
+timeCreated: 1509151723
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UWBNetworkingPackage/Scripts/ObjectManager.cs
+++ b/UWBNetworkingPackage/Scripts/ObjectManager.cs
@@ -453,10 +453,10 @@ namespace UWBNetworkingPackage
         
         private void RaiseSyncSceneEventHandler(int otherPlayerID, bool forceSync)
         {
+            UnityEngine.Debug.Log("Raising Scene Sync handler");
+
             if (PhotonNetwork.isMasterClient || forceSync)
             {
-                UnityEngine.Debug.Log(otherPlayerID + " player joined. Sending sync");
-
                 List<GameObject> ASLObjectList = GrabAllASLObjects();
 
                 NetworkingPeer peer = PhotonNetwork.networkingPeer;
@@ -472,10 +472,11 @@ namespace UWBNetworkingPackage
                     syncSceneData[(byte)0] = otherPlayerID;
 
 #if UNITY_EDITOR
-                    string prefabName = UnityEditor.PrefabUtility.GetPrefabObject(go).name;
+                    string prefabName = UnityEditor.PrefabUtility.GetPrefabParent(go).name;
 #else
                     string prefabName = go.name;
 #endif
+                    UnityEngine.Debug.Log("Prefab name = " + prefabName);
                     syncSceneData[(byte)1] = prefabName;
 
                     if (go.transform.position != Vector3.zero)
@@ -536,8 +537,6 @@ namespace UWBNetworkingPackage
         {
             Debug.Log("OnEvent method triggered.");
 
-            UnityEngine.Debug.Log("On Event triggered with event code " + (int)eventCode);
-
             if (PhotonNetwork.logLevel >= PhotonLogLevel.Informational)
             {
                 Debug.Log(string.Format("Custom OnEvent for CreateObject: {0}", eventCode.ToString()));
@@ -553,7 +552,6 @@ namespace UWBNetworkingPackage
             }
             else if (eventCode.Equals(ASLEventCode.EV_JOIN))
             {
-                Debug.Log("Player joined");
                 RaiseSyncSceneEventHandler(senderID, false);
             }
             else if (eventCode.Equals(ASLEventCode.EV_SYNCSCENE))

--- a/UWBNetworkingPackage/Scripts/ObjectManager.cs
+++ b/UWBNetworkingPackage/Scripts/ObjectManager.cs
@@ -159,6 +159,7 @@ namespace UWBNetworkingPackage
             go.name = prefabGo.name;
 
             HandleLocalLogic(go);
+            RegisterObjectCreation(go, prefabName);
 
             return go;
         }
@@ -414,7 +415,8 @@ namespace UWBNetworkingPackage
 #if UNITY_EDITOR
             string prefabName = UnityEditor.PrefabUtility.GetPrefabParent(go).name;
 #else
-            string prefabName = go.name;
+            //string prefabName = go.name;
+            string prefabName = ObjectInstantiationDatabase.GetPrefabName(go);
 #endif
             instantiateEvent[(byte)0] = prefabName;
 
@@ -474,7 +476,8 @@ namespace UWBNetworkingPackage
 #if UNITY_EDITOR
                     string prefabName = UnityEditor.PrefabUtility.GetPrefabParent(go).name;
 #else
-                    string prefabName = go.name;
+                    //string prefabName = go.name;
+                    string prefabName = ObjectInstantiationDatabase.GetPrefabName(go);
 #endif
                     UnityEngine.Debug.Log("Prefab name = " + prefabName);
                     syncSceneData[(byte)1] = prefabName;
@@ -605,6 +608,8 @@ namespace UWBNetworkingPackage
             HandleLocalLogic(go, viewIDs);
             go.transform.position = position;
             go.transform.rotation = rotation;
+
+            RegisterObjectCreation(go, prefabName);
         }
 
         private GameObject HandleLocalLogic(GameObject go, int[] viewIDs)
@@ -655,6 +660,8 @@ namespace UWBNetworkingPackage
                 }
 
                 GameObject.Destroy(go);
+
+                RegisterObjectDeletion(go, go.name);
             }
         }
 
@@ -748,6 +755,18 @@ namespace UWBNetworkingPackage
 
             return goList;
         }
+
+        #region Instantiation Database
+        private void RegisterObjectCreation(GameObject go, string prefabName)
+        {
+            ObjectInstantiationDatabase.Add(prefabName, go);
+        }
+
+        private void RegisterObjectDeletion(GameObject go, string goName)
+        {
+            ObjectInstantiationDatabase.Remove(go, goName);
+        }
+#endregion
         #endregion
         #endregion
     }

--- a/UWBNetworkingPackage/Scripts/ObjectManager.cs
+++ b/UWBNetworkingPackage/Scripts/ObjectManager.cs
@@ -455,8 +455,6 @@ namespace UWBNetworkingPackage
         
         private void RaiseSyncSceneEventHandler(int otherPlayerID, bool forceSync)
         {
-            UnityEngine.Debug.Log("Raising Scene Sync handler");
-
             if (PhotonNetwork.isMasterClient || forceSync)
             {
                 List<GameObject> ASLObjectList = GrabAllASLObjects();

--- a/UWBNetworkingPackage/Scripts/ObjectManager.cs
+++ b/UWBNetworkingPackage/Scripts/ObjectManager.cs
@@ -154,7 +154,11 @@ namespace UWBNetworkingPackage
                 Debug.LogError("Failed to Instantiate prefab: " + prefabName + ".");
                 return null;
             }
+#if UNITY_EDITOR
+            GameObject go = UnityEditor.PrefabUtility.InstantiatePrefab(prefabGo) as GameObject;
+#else
             GameObject go = GameObject.Instantiate(prefabGo);
+#endif
             go.name = prefabGo.name;
 
             HandleLocalLogic(go);
@@ -164,7 +168,6 @@ namespace UWBNetworkingPackage
 
         private bool RetrieveFromPUNCache(string prefabName, out GameObject prefabGo)
         {
-
             bool UsePrefabCache = true;
 
             if (!UsePrefabCache || !PhotonNetwork.PrefabCache.TryGetValue(prefabName, out prefabGo))
@@ -472,7 +475,7 @@ namespace UWBNetworkingPackage
 #if UNITY_EDITOR
                     string prefabName = UnityEditor.PrefabUtility.GetPrefabObject(go).name;
 #else
-                string prefabName = go.name;
+                    string prefabName = go.name;
 #endif
                     syncSceneData[(byte)1] = prefabName;
 
@@ -592,7 +595,11 @@ namespace UWBNetworkingPackage
                 return;
             }
 
+#if UNITY_EDITOR
+            GameObject go = UnityEditor.PrefabUtility.InstantiatePrefab(prefabGo) as GameObject;
+#else
             GameObject go = GameObject.Instantiate(prefabGo);
+#endif
             go.name = prefabGo.name;
 
             HandleLocalLogic(go, viewIDs);

--- a/UWBNetworkingPackage/Scripts/ReceivingClientLauncher.cs
+++ b/UWBNetworkingPackage/Scripts/ReceivingClientLauncher.cs
@@ -111,6 +111,7 @@ namespace UWBNetworkingPackage
         /// </summary>
         public override void OnJoinedRoom()
         {
+            base.OnJoinedRoom();
             Debug.Log("Client joined room.");
             
 

--- a/UWBNetworkingPackage/Scripts/SceneSynchronizationManager.cs
+++ b/UWBNetworkingPackage/Scripts/SceneSynchronizationManager.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UWBNetworkingPackage
+{
+    /// <summary>
+    /// This class is currently empty, but is intended as a placeholder for 
+    /// future logic that handles scene synchronization beyond the basic 
+    /// object synchronization encapsulated in NetworkManager's ObjectManager. 
+    /// 
+    /// Examples of this logic may be restricting kinds of nodes that may 
+    /// join/sync to a given room/configuration, saving/loading scenes, 
+    /// checkpointing work in case of network disconnections/crashes, and 
+    /// reconciliation of items that conflicting scene synchronization records 
+    /// (i.e. master client synchronization is from an earlier checkpoint than 
+    /// the joining client or a disconnection caused a branching update tree 
+    /// that needs to be resolved).
+    /// </summary>
+    public class SceneSynchronizationManager : MonoBehaviour
+    {
+        private ObjectManager objManager;
+
+        public void Awake()
+        {
+            objManager = GameObject.FindObjectOfType<ObjectManager>();
+        }
+
+        // Insert logic here
+    }
+}

--- a/UWBNetworkingPackage/Scripts/SceneSynchronizationManager.cs.meta
+++ b/UWBNetworkingPackage/Scripts/SceneSynchronizationManager.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1b4685a1656cb1f4b9d6df92eded2fbc
+timeCreated: 1509139490
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Updated ASL to automatically sync up receiving client scenes upon joining. It is assumed that the joining member has no items that they want to contribute to ASL, as ASL handles all initial synchronization on startup/connection to the network.

Synchronization is handled through ObjectManager and takes GameObjects with PUN scripts to force their initial synchronization through remote instantiation. Any behavior outside of joining the room to sync up is not currently supported (such as saving scenes or loading scenes during runtime).

If opting to improve the system so that there is two-way communication on what items are missing and having receiving clients request these items specifically, you may want to look into ObjectManager, ObjectInfoMetadata, ObjectInstantiationMetadata, and your own custom communication protocol through PUN's event system (i.e. look at ASLEventCode).