### PR TITLE
Ownership Tweaking

### DIFF
--- a/Manipulation/Controllers/Android/TapBehavior.cs
+++ b/Manipulation/Controllers/Android/TapBehavior.cs
@@ -30,7 +30,7 @@ namespace ASL.Manipulation.Controllers.Android
                     break;
                 case TouchPhase.Stationary:
                     GameObject go = selectBehavior.Select(touchInfo);
-                    objManager.RequestOwnership(go, PhotonNetwork.player.ID);
+                    objManager.RequestOwnership(go);
                     break;
                 case TouchPhase.Moved:
                     moveBehavior.Drag(touchInfo.deltaPosition);

--- a/Manipulation/Controllers/PC/Keyboard.cs
+++ b/Manipulation/Controllers/PC/Keyboard.cs
@@ -62,6 +62,15 @@ namespace ASL.Manipulation.Controllers.PC
                 UWBNetworkingPackage.NetworkManager nm = GameObject.Find("NetworkManager").GetComponent<UWBNetworkingPackage.NetworkManager>();
                 nm.UnRestrictOwnership(go);
             }
+
+            if (Input.GetKey(KeyCode.O))
+            {
+                List<int> IDsToAdd = new List<int>();
+                IDsToAdd.Add(2);
+                UWBNetworkingPackage.NetworkManager nm = GameObject.Find("NetworkManager").GetComponent<UWBNetworkingPackage.NetworkManager>();
+                GameObject go = GameObject.Find("Sphere");
+                nm.WhiteListOwnership(go, IDsToAdd);
+            }
         }
 
         public MoveBehavior MoveBehavior

--- a/Manipulation/Controllers/PC/Keyboard.cs
+++ b/Manipulation/Controllers/PC/Keyboard.cs
@@ -55,6 +55,13 @@ namespace ASL.Manipulation.Controllers.PC
                 //objManager.Instantiate(prefabName);
                 objManager.InstantiateOwnedObject(prefabName);
             }
+
+            if (Input.GetKey(KeyCode.P))
+            {
+                GameObject go = GameObject.Find("Sphere");
+                UWBNetworkingPackage.NetworkManager nm = GameObject.Find("NetworkManager").GetComponent<UWBNetworkingPackage.NetworkManager>();
+                nm.UnRestrictOwnership(go);
+            }
         }
 
         public MoveBehavior MoveBehavior

--- a/Manipulation/Controllers/PC/Keyboard.cs
+++ b/Manipulation/Controllers/PC/Keyboard.cs
@@ -52,7 +52,8 @@ namespace ASL.Manipulation.Controllers.PC
             {
                 //gameObject.GetComponent<CreateObject>().CreatePUNObject("Rooms/Room2/Room2");
                 string prefabName = "Rooms/Room2/Room2";
-                objManager.Instantiate(prefabName);
+                //objManager.Instantiate(prefabName);
+                objManager.InstantiateOwnedObject(prefabName);
             }
         }
 

--- a/Manipulation/Controllers/PC/Mouse.cs
+++ b/Manipulation/Controllers/PC/Mouse.cs
@@ -19,7 +19,7 @@ namespace ASL.Manipulation.Controllers.PC
             if (Input.GetMouseButtonDown(0))
             {
                 GameObject selectedObject = Select();
-                objManager.RequestOwnership(selectedObject, PhotonNetwork.player.ID);
+                objManager.RequestOwnership(selectedObject);
             }
             if (Input.GetMouseButtonDown(1))
             {
@@ -27,7 +27,15 @@ namespace ASL.Manipulation.Controllers.PC
                 Vector3 position = new Vector3(0, 0, 2);
                 Quaternion rotation = Quaternion.identity;
                 Vector3 scale = Vector3.one;
-                objManager.Instantiate(prefabName, position, rotation, scale);
+                //objManager.Instantiate(prefabName, position, rotation, scale);
+                GameObject go = objManager.Instantiate(prefabName);
+                go.transform.Translate(position);
+
+                UWBNetworkingPackage.NetworkManager nm = GameObject.Find("NetworkManager").GetComponent<UWBNetworkingPackage.NetworkManager>();
+                List<int> IDsToAdd = new List<int>();
+                IDsToAdd.Add(1);
+                //nm.WhiteListOwnership(go, IDsToAdd);
+                nm.RestrictOwnership(go, IDsToAdd);
             }
         }
 

--- a/Manipulation/Controllers/PC/Mouse.cs
+++ b/Manipulation/Controllers/PC/Mouse.cs
@@ -28,14 +28,15 @@ namespace ASL.Manipulation.Controllers.PC
                 Quaternion rotation = Quaternion.identity;
                 Vector3 scale = Vector3.one;
                 //objManager.Instantiate(prefabName, position, rotation, scale);
-                GameObject go = objManager.Instantiate(prefabName);
+                //GameObject go = objManager.Instantiate(prefabName);
+                GameObject go = objManager.InstantiateOwnedObject(prefabName);
                 go.transform.Translate(position);
 
                 UWBNetworkingPackage.NetworkManager nm = GameObject.Find("NetworkManager").GetComponent<UWBNetworkingPackage.NetworkManager>();
                 List<int> IDsToAdd = new List<int>();
-                IDsToAdd.Add(1);
-                //nm.WhiteListOwnership(go, IDsToAdd);
-                nm.RestrictOwnership(go, IDsToAdd);
+                IDsToAdd.Add(2);
+                nm.WhiteListOwnership(go, IDsToAdd);
+                //nm.RestrictOwnership(go, IDsToAdd);
             }
         }
 

--- a/Manipulation/Controllers/Vive/TipTracker.cs
+++ b/Manipulation/Controllers/Vive/TipTracker.cs
@@ -78,7 +78,7 @@ namespace ASL.Manipulation.Controllers.Vive
             }
 
             //objManager.GetComponent<ObjectInteractionManager>().RequestOwnership(hit.collider.gameObject, PhotonNetwork.player.ID);
-            objManager.RequestOwnership(hit.collider.gameObject, PhotonNetwork.player.ID);
+            objManager.RequestOwnership(hit.collider.gameObject);
         }
 
         public void Unselect(object sender, ControllerInteractionEventArgs e)
@@ -86,7 +86,7 @@ namespace ASL.Manipulation.Controllers.Vive
             bool isLeftController;
             GameObject controllerAvatar = GetViveControllerAvatar(e.controllerReference, out isLeftController);
             //objManager.GetComponent<ObjectInteractionManager>().Focus(null, PhotonNetwork.player.ID);
-            objManager.Focus(null, PhotonNetwork.player.ID);
+            objManager.Focus(null);
             if (isLeftController)
             {
                 leftSelectedObject = null;

--- a/Manipulation/Objects/Android/SelectObject.cs
+++ b/Manipulation/Objects/Android/SelectObject.cs
@@ -42,7 +42,7 @@ namespace ASL.Manipulation.Objects.Android
 
         public void Unselect(Touch touchInfo)
         {
-            objManager.Focus(null, PhotonNetwork.player.ID);
+            objManager.Focus(null);
         }
     }
 }

--- a/Manipulation/Objects/ObjectInteractionManager.cs
+++ b/Manipulation/Objects/ObjectInteractionManager.cs
@@ -29,7 +29,7 @@ namespace ASL.Manipulation.Objects
             {
                 if (obj.GetPhotonView() != null)
                 {
-                    FocusObjectChangedEvent(new ObjectSelectedEventArgs(obj, obj.GetPhotonView().owner.ID, focuserID));
+                    FocusObjectChangedEvent(new ObjectSelectedEventArgs(obj, obj.GetPhotonView().ownerId, focuserID));
                 }
                 else
                 {

--- a/Manipulation/Objects/ObjectInteractionManager.cs
+++ b/Manipulation/Objects/ObjectInteractionManager.cs
@@ -10,19 +10,20 @@ namespace ASL.Manipulation.Objects
         private UWBNetworkingPackage.NetworkManager networkManager;
         public event ObjectSelectedEventHandler FocusObjectChangedEvent;
 
-        public void RequestOwnership(GameObject obj, int focuserID)
+        public void RequestOwnership(GameObject obj)
         {
-            OnObjectSelected(obj, focuserID);
-            networkManager.RequestOwnership(obj, focuserID);
+            OnObjectSelected(obj);
+            networkManager.RequestOwnership(obj);
         }
 
-        public void Focus(GameObject obj, int focuserID)
+        public void Focus(GameObject obj)
         {
-            OnObjectSelected(obj, focuserID);
+            OnObjectSelected(obj);
         }
 
-        protected void OnObjectSelected(GameObject obj, int focuserID)
+        protected void OnObjectSelected(GameObject obj)
         {
+            int focuserID = PhotonNetwork.player.ID;
             //Debug.Log("About to trigger On Object Selected event");
             if (obj != null)
             {
@@ -81,21 +82,31 @@ namespace ASL.Manipulation.Objects
             }
         }
 
-        public void Instantiate(GameObject go)
+        public GameObject Instantiate(GameObject go)
         {
-            networkManager.Instantiate(go);
+            return networkManager.Instantiate(go);
         }
 
-        public void Instantiate(string prefabName)
+        public GameObject Instantiate(string prefabName)
         {
-            networkManager.Instantiate(prefabName);
+            return networkManager.Instantiate(prefabName);
         }
 
-        public void Instantiate(string prefabName, Vector3 position, Quaternion rotation, Vector3 scale)
+        public GameObject Instantiate(string prefabName, Vector3 position, Quaternion rotation, Vector3 scale)
         {
-            networkManager.Instantiate(prefabName, position, rotation, scale);
+            return networkManager.Instantiate(prefabName, position, rotation, scale);
         }
 
+        public GameObject InstantiateOwnedObject(string prefabName)
+        {
+            return networkManager.InstantiateOwnedObject(prefabName);
+        }
+
+        public bool Destroy(GameObject go)
+        {
+            return networkManager.Destroy(go);
+        }
+        
         public T RegisterBehavior<T>()
         {
             if(gameObject.GetComponent<T>() != null)

--- a/Resources/Rooms/temp.meta
+++ b/Resources/Rooms/temp.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c3f20268ab751e442a1c68c95d703058
+folderAsset: yes
+timeCreated: 1515031873
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UWBNetworkingPackage/Scripts/ASLEventCode.cs
+++ b/UWBNetworkingPackage/Scripts/ASLEventCode.cs
@@ -10,5 +10,6 @@ namespace UWBNetworkingPackage
         public const byte EV_DESTROYOBJECT = 98;
         public const byte EV_SYNCSCENE = 97;
         public const byte EV_JOIN = 55;
+        public const byte EV_SYNC_OBJECT_OWNERSHIP_RESTRICTION = 96;
     }
 }

--- a/UWBNetworkingPackage/Scripts/AutoOwnership/OwnableObject.cs
+++ b/UWBNetworkingPackage/Scripts/AutoOwnership/OwnableObject.cs
@@ -8,11 +8,16 @@ namespace UWBNetworkingPackage
     public class OwnableObject : Photon.PunBehaviour
     {
         private int SCENE_VALUE = 0;    // Hidden feature: assigning ownership to '0' makes object a scene object
+        private bool isRestricted = false;
+        private List<int> restrictedIDs;
 
         // Add object behavior components
-        protected void Start()
+        protected void Awake()
         {
             //gameObject.AddComponent<ASL.UI.Mouse.OwnershipTransfer>();
+            restrictedIDs = new List<int>();
+            PhotonView pv = gameObject.GetPhotonView();
+            pv.ownershipTransfer = OwnershipOption.Takeover;
         }
 
         // Fire an event when instantiated
@@ -20,7 +25,7 @@ namespace UWBNetworkingPackage
         public override void OnPhotonInstantiate(PhotonMessageInfo info)
         {
             base.OnPhotonInstantiate(info);
-            this.gameObject.GetPhotonView().TransferOwnership(SCENE_VALUE);
+            //this.gameObject.GetPhotonView().TransferOwnership(SCENE_VALUE);
         }
 
         [PunRPC]
@@ -47,19 +52,7 @@ namespace UWBNetworkingPackage
                 return false;
             }
         }
-
-        public PhotonPlayer GetOwner()
-        {
-            if (gameObject.GetComponent<PhotonView>() != null)
-            {
-                return gameObject.GetComponent<PhotonView>().owner;
-            }
-            else
-            {
-                return null;
-            }
-        }
-
+        
         public void RelinquishOwnership(int newPlayerID)
         {
             // Ignore all items tagged with "room" tag
@@ -69,12 +62,290 @@ namespace UWBNetworkingPackage
                 {
                     photonView.TransferOwnership(newPlayerID);
                 }
-                else if (gameObject.GetPhotonView().owner.Equals(SCENE_VALUE)
-                    && PhotonNetwork.isMasterClient)
+                else if (gameObject.GetPhotonView().owner.Equals(SCENE_VALUE))
                 {
                     photonView.RequestOwnership();
+                    photonView.TransferOwnership(newPlayerID);
                 }
                 gameObject.GetPhotonView().ownerId = newPlayerID;
+            }
+        }
+
+        public bool CanTake()
+        {
+            if (StoredInScene || !isRestricted || (isRestricted && restrictedIDs.Contains(PhotonNetwork.player.ID)))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public bool Take()
+        {
+            PhotonView pv = gameObject.GetPhotonView();
+            if (gameObject.GetPhotonView() != null)
+            {
+                bool owned = HasOwnership(PhotonNetwork.player);
+                if (StoredInScene)
+                {
+                    pv.RequestOwnership();
+                }
+                else if (CanTake() && !owned)
+                {
+                    pv.RPC("Grab", PhotonTargets.Others);
+                }
+
+                if (HasOwnership(PhotonNetwork.player))
+                {
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        // restrict and add yourself to the list of ownable IDs
+        // returns list of ownable IDs
+        public List<int> Restrict()
+        {
+            if (!isRestricted && Take())
+            {
+                isRestricted = true;
+                if (!restrictedIDs.Contains(PhotonNetwork.player.ID))
+                {
+                    restrictedIDs.Add(PhotonNetwork.player.ID);
+                }
+
+                // propagate restriction event
+                ObjectManager objManager = GameObject.FindObjectOfType<ObjectManager>();
+                if(objManager != null)
+                {
+                    objManager.SetObjectRestrictions(gameObject, true, restrictedIDs);
+                }
+
+                PhotonView pv = gameObject.GetPhotonView();
+                pv.ownershipTransfer = OwnershipOption.Request;
+
+                return OwnablePlayerIDs;
+            }
+            else if (isRestricted)
+            {
+                return OwnablePlayerIDs;
+            }
+            else
+            {
+                Debug.LogWarning("Ownership restriction failed.");
+                return null;
+            }
+        }
+
+        public List<int> RestrictToYourself()
+        {
+            if (!isRestricted && Take())
+            {
+                ClearOwnablePlayerIDs();
+                return Restrict();
+            }
+            else if (isRestricted)
+            {
+                return OwnablePlayerIDs;
+            }
+            else
+            {
+                Debug.LogWarning("Ownership restriction failed.");
+                return null;
+            }
+        }
+
+        public bool UnRestrict()
+        {
+            if(isRestricted && Take())
+            {
+                isRestricted = false;
+                
+                // propagate restriction event
+                ObjectManager objManager = GameObject.FindObjectOfType<ObjectManager>();
+                if (objManager != null)
+                {
+                    objManager.SetObjectRestrictions(gameObject, false, restrictedIDs);
+                }
+
+                PhotonView pv = gameObject.GetPhotonView();
+                pv.ownershipTransfer = OwnershipOption.Takeover;
+
+                return true;
+            }
+            else if (!isRestricted)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public void SetRestrictions(bool restricted, int[] ownableIDs)
+        {
+            isRestricted = restricted;
+            if (isRestricted)
+            {
+                PhotonView pv = gameObject.GetPhotonView();
+                pv.ownershipTransfer = OwnershipOption.Request;
+            }
+            else
+            {
+                PhotonView pv = gameObject.GetPhotonView();
+                pv.ownershipTransfer = OwnershipOption.Takeover;
+            }
+
+            ClearOwnablePlayerIDs();
+            bool ownable = false;
+            if (ownableIDs != null)
+            {
+                foreach (int id in ownableIDs)
+                {
+                    restrictedIDs.Add(id);
+                    if (id == PhotonNetwork.player.ID)
+                    {
+                        ownable = true;
+                    }
+                }
+            }
+
+            // Handle edge case where you're ripping ownership away from someone who owns the object
+            if(HasOwnership(PhotonNetwork.player) && !ownable)
+            {
+                PhotonView pv = gameObject.GetPhotonView();
+                if(pv != null)
+                {
+                    pv.TransferOwnership(0);
+                }
+            }
+        }
+
+        public void WhiteListPlayerID(List<int> playerIDs)
+        {
+            bool changed = false;
+
+            if (playerIDs != null)
+            {
+                foreach (int id in playerIDs)
+                {
+                    if (!restrictedIDs.Contains(id))
+                    {
+                        restrictedIDs.Add(id);
+                        changed = true;
+                    }
+                }
+            }
+
+            // propagate restriction event
+            if (changed)
+            {
+                ObjectManager objManager = GameObject.FindObjectOfType<ObjectManager>();
+                if (objManager != null)
+                {
+                    objManager.SetObjectRestrictions(gameObject, isRestricted, restrictedIDs);
+                }
+            }
+        }
+
+        public void BlackListPlayerID(List<int> playerIDs)
+        {
+            bool changed = false;
+
+            if (playerIDs != null)
+            {
+                foreach (int id in playerIDs)
+                {
+                    if (restrictedIDs.Contains(id))
+                    {
+                        restrictedIDs.Remove(id);
+                        changed = true;
+                    }
+                }
+            }
+
+            // propagate restriction event
+            if (changed)
+            {
+                ObjectManager objManager = GameObject.FindObjectOfType<ObjectManager>();
+                if (objManager != null)
+                {
+                    objManager.SetObjectRestrictions(gameObject, isRestricted, restrictedIDs);
+                }
+            }
+        }
+
+        public void ClearOwnablePlayerIDs()
+        {
+            restrictedIDs.Clear();
+        }
+
+        // ERROR TESTING - FIX
+        public bool IsOwnershipRestricted
+        {
+            get
+            {
+                return isRestricted;
+            }
+        }
+
+        /// <summary>
+        /// Not very fast. Returns a safe copy of the restricted IDs. Use "CanTake" method to determine if available in this list.
+        /// </summary>
+        public List<int> OwnablePlayerIDs
+        {
+            get
+            {
+                List<int> copy = new List<int>();
+                foreach(int id in restrictedIDs)
+                {
+                    copy.Add(id);
+                }
+
+                return copy;
+            }
+        }
+
+        public int OwnerID
+        {
+            get
+            {
+                return gameObject.GetPhotonView().ownerId;
+            }
+        }
+
+        public PhotonPlayer Owner
+        {
+            get
+            {
+                if (gameObject.GetComponent<PhotonView>() != null)
+                {
+                    return gameObject.GetComponent<PhotonView>().owner;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        }
+
+        public bool StoredInScene
+        {
+            get
+            {
+                return OwnerID == SCENE_VALUE;
             }
         }
     }

--- a/UWBNetworkingPackage/Scripts/AutoOwnership/OwnableObject.cs
+++ b/UWBNetworkingPackage/Scripts/AutoOwnership/OwnableObject.cs
@@ -92,6 +92,7 @@ namespace UWBNetworkingPackage
                 if (StoredInScene)
                 {
                     pv.RequestOwnership();
+                    pv.ownerId = PhotonNetwork.player.ID;
                 }
                 else if (CanTake() && !owned)
                 {

--- a/UWBNetworkingPackage/Scripts/AutoOwnership/OwnableObject.cs
+++ b/UWBNetworkingPackage/Scripts/AutoOwnership/OwnableObject.cs
@@ -133,7 +133,7 @@ namespace UWBNetworkingPackage
                 }
 
                 PhotonView pv = gameObject.GetPhotonView();
-                pv.ownershipTransfer = OwnershipOption.Request;
+                pv.ownershipTransfer = OwnershipOption.Fixed;
 
                 return OwnablePlayerIDs;
             }
@@ -200,7 +200,7 @@ namespace UWBNetworkingPackage
             if (isRestricted)
             {
                 PhotonView pv = gameObject.GetPhotonView();
-                pv.ownershipTransfer = OwnershipOption.Request;
+                pv.ownershipTransfer = OwnershipOption.Fixed;
             }
             else
             {

--- a/UWBNetworkingPackage/Scripts/DestroyObjectSynchronizer.cs
+++ b/UWBNetworkingPackage/Scripts/DestroyObjectSynchronizer.cs
@@ -25,7 +25,7 @@ namespace UWBNetworkingPackage
             if(view != null)
             {
                 int viewID = view.viewID;
-                objManager.DestroyObject(this.name, viewID);
+                objManager.DestroyHandler(this.name, viewID);
             }
         }
     }

--- a/UWBNetworkingPackage/Scripts/MasterClientLauncher.cs
+++ b/UWBNetworkingPackage/Scripts/MasterClientLauncher.cs
@@ -163,7 +163,7 @@ namespace UWBNetworkingPackage
         {
             SendTangoRoomInfo(newPlayer.ID);
 
-            UnityEngine.Debug.Log("Player Connected, Send Tango Mesh");
+            //UnityEngine.Debug.Log("Player Connected, Send Tango Mesh");
 
             base.OnPhotonPlayerConnected(newPlayer);
         }

--- a/UWBNetworkingPackage/Scripts/NetworkManager.cs
+++ b/UWBNetworkingPackage/Scripts/NetworkManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Photon;
 using UnityEngine;
 //using UnityEditor;
@@ -157,36 +158,120 @@ namespace UWBNetworkingPackage
 #endif
         }
 
-        public void Instantiate(GameObject go)
+        public GameObject Instantiate(GameObject go)
         {
             if(objManager != null)
             {
-                objManager.Instantiate(go);
+                return objManager.Instantiate(go);
+            }
+            else
+            {
+                return null;
             }
         }
 
-        public void Instantiate(string prefabName)
+        public GameObject Instantiate(string prefabName)
         {
             if(objManager != null)
             {
-                objManager.Instantiate(prefabName);
+                return objManager.Instantiate(prefabName);
+            }
+            else
+            {
+                return null;
             }
         }
 
-        public void Instantiate(string prefabName, Vector3 position, Quaternion rotation, Vector3 scale)
+        public GameObject Instantiate(string prefabName, Vector3 position, Quaternion rotation, Vector3 scale)
         {
             if(objManager != null)
             {
-                objManager.Instantiate(prefabName, position, rotation, scale);
+                return objManager.Instantiate(prefabName, position, rotation, scale);
+            }
+            else
+            {
+                return null;
             }
         }
 
-        public void RequestOwnership(GameObject obj, int focuserID)
+        public GameObject InstantiateOwnedObject(string prefabName)
         {
-            if (obj.GetPhotonView() != null)
+            if(objManager != null)
             {
-                obj.GetPhotonView().RPC("Grab", PhotonTargets.Others);
+                return objManager.InstantiateOwnedObject(prefabName);
             }
+            else
+            {
+                return null;
+            }
+        }
+
+        public bool Destroy(GameObject go)
+        {
+            if (go == null)
+            {
+                return true;
+            }
+            else
+            {
+                OwnableObject ownershipManager = go.GetComponent<OwnableObject>();
+                if (ownershipManager.Take())
+                {
+                    UnityEngine.GameObject.Destroy(go);
+                    // Calling Unity's Destroy mechanism kills the object by triggering an OnDestroy call in the ObjectManager
+                }
+
+                return true;
+            }
+        }
+
+        public bool RequestOwnership(GameObject obj)
+        {
+            OwnableObject ownershipManager = obj.GetComponent<OwnableObject>();
+            if(ownershipManager != null)
+            {
+                return ownershipManager.Take();
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public bool RestrictOwnership(GameObject obj, List<int> whiteListIDs)
+        {
+            OwnableObject ownershipManager = obj.GetComponent<OwnableObject>();
+            List<int> returnValue = ownershipManager.RestrictToYourself();
+            if (returnValue != null)
+            {
+                if (whiteListIDs != null)
+                {
+                    ownershipManager.WhiteListPlayerID(whiteListIDs);
+                }
+
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public bool UnRestrictOwnership(GameObject obj)
+        {
+            OwnableObject ownershipManager = obj.GetComponent<OwnableObject>();
+            return ownershipManager.UnRestrict();
+        }
+
+        public void WhiteListOwnership(GameObject obj, List<int> playerIDs)
+        {
+            obj.GetComponent<OwnableObject>().WhiteListPlayerID(playerIDs);
+        }
+
+        // Ownership must be restricted before blacklisting can take effect
+        public void BlackListOwnership(GameObject obj, List<int> playerIDs)
+        {
+            obj.GetComponent<OwnableObject>().BlackListPlayerID(playerIDs);
         }
 
         public void SendTangoMesh()

--- a/UWBNetworkingPackage/Scripts/ObjectManager.cs
+++ b/UWBNetworkingPackage/Scripts/ObjectManager.cs
@@ -61,7 +61,7 @@ namespace UWBNetworkingPackage
                 RaiseInstantiateEventHandler(localObj);
                 int[] whiteListIDs = new int[1];
                 whiteListIDs[0] = PhotonNetwork.player.ID;
-                UnityEngine.Debug.Log("About to raise restriction event.");
+                //UnityEngine.Debug.Log("About to raise restriction event.");
                 OwnableObject ownershipManager = localObj.GetComponent<OwnableObject>();
                 ownershipManager.SetRestrictions(true, whiteListIDs);
                 RaiseObjectOwnershipRestrictionEventHandler(localObj, true, whiteListIDs);
@@ -475,7 +475,7 @@ namespace UWBNetworkingPackage
                     //string prefabName = go.name;
                     string prefabName = ObjectInstantiationDatabase.GetPrefabName(go);
 #endif
-                    UnityEngine.Debug.Log("Prefab name = " + prefabName);
+                    //UnityEngine.Debug.Log("Prefab name = " + prefabName);
                     syncSceneData[(byte)1] = prefabName;
 
                     if (go.transform.position != Vector3.zero)
@@ -504,6 +504,7 @@ namespace UWBNetworkingPackage
                     syncSceneData[(byte)9] = ownershipManager.IsOwnershipRestricted;
                     List<int> whiteListIDs = ownershipManager.OwnablePlayerIDs;
                     int[] idList = new int[whiteListIDs.Count];
+                    whiteListIDs.CopyTo(idList);
                     syncSceneData[(byte)10] = idList;
 
                     //RaiseEventOptions options = new RaiseEventOptions();
@@ -543,7 +544,7 @@ namespace UWBNetworkingPackage
         {
             NetworkingPeer peer = PhotonNetwork.networkingPeer;
 
-            UnityEngine.Debug.Log("restricted = " + ((restricted) ? "true" : "false"));
+            //UnityEngine.Debug.Log("restricted = " + ((restricted) ? "true" : "false"));
 
             ExitGames.Client.Photon.Hashtable restrictionEvent = new ExitGames.Client.Photon.Hashtable();
             PhotonView pv = go.GetComponent<PhotonView>();
@@ -552,6 +553,11 @@ namespace UWBNetworkingPackage
             restrictionEvent[(byte)2] = restricted;
             restrictionEvent[(byte)3] = ownableIDs;
             restrictionEvent[(byte)4] = PhotonNetwork.ServerTimestamp;
+
+            //foreach(int id in ownableIDs)
+            //{
+            //    UnityEngine.Debug.Log("Sending ownableID of " + id);
+            //}
 
             RaiseEventOptions options = new RaiseEventOptions();
             options.Receivers = ReceiverGroup.All;
@@ -736,7 +742,7 @@ namespace UWBNetworkingPackage
             int[] ownableIDs = (int[])eventData[(byte)3];
             int serverTimeStamp = (int)eventData[(byte)4];
             
-            UnityEngine.Debug.Log("restricted = " + ((restricted) ? "true" : "false"));
+            //UnityEngine.Debug.Log("restricted = " + ((restricted) ? "true" : "false"));
 
             GameObject[] objs = GameObject.FindObjectsOfType<GameObject>();
             GameObject go = null;

--- a/UWBNetworkingPackage/Scripts/ObjectManager.cs
+++ b/UWBNetworkingPackage/Scripts/ObjectManager.cs
@@ -62,6 +62,8 @@ namespace UWBNetworkingPackage
                 int[] whiteListIDs = new int[1];
                 whiteListIDs[0] = PhotonNetwork.player.ID;
                 UnityEngine.Debug.Log("About to raise restriction event.");
+                OwnableObject ownershipManager = localObj.GetComponent<OwnableObject>();
+                ownershipManager.SetRestrictions(true, whiteListIDs);
                 RaiseObjectOwnershipRestrictionEventHandler(localObj, true, whiteListIDs);
             }
             return localObj;
@@ -541,6 +543,8 @@ namespace UWBNetworkingPackage
         {
             NetworkingPeer peer = PhotonNetwork.networkingPeer;
 
+            UnityEngine.Debug.Log("restricted = " + ((restricted) ? "true" : "false"));
+
             ExitGames.Client.Photon.Hashtable restrictionEvent = new ExitGames.Client.Photon.Hashtable();
             PhotonView pv = go.GetComponent<PhotonView>();
             restrictionEvent[(byte)0] = go.name;
@@ -731,6 +735,8 @@ namespace UWBNetworkingPackage
             bool restricted = (bool)eventData[(byte)2];
             int[] ownableIDs = (int[])eventData[(byte)3];
             int serverTimeStamp = (int)eventData[(byte)4];
+            
+            UnityEngine.Debug.Log("restricted = " + ((restricted) ? "true" : "false"));
 
             GameObject[] objs = GameObject.FindObjectsOfType<GameObject>();
             GameObject go = null;


### PR DESCRIPTION
-- Cleaned ownership method signatures:
  1) ObjectInteractionManager.RequestOwnership: Removed required parameter of player ID
  2) ObjectInteractionManager.Focus: Removed required parameter of player ID.
  3) ObjectInteractionManager.OnObjectSelected: Removed required parameter of player ID.
  4) ObjectInteractionManager.Instantiate: Changed return type of all Instantiate methods from void to GameObject so that a person can immediately get a reference to a created object.
  5) NetworkManager.Instantiate: Changed return type of all Instantiate methods from void to GameObject so that a person can immediately get a reference to a created object.

-- Generated new methods:
  1) ObjectInteractionManager.InstantiateOwnedObject: Create a prefab object similar to Instantiate method, but this one is locked so that only you can move it (i.e. PUN sharing setting is "Fixed")
  2) ObjectInteractionManager.Destroy: Explicitly destroy a managed ASL object. Simple wrapper to call a Destroy on the GameObject if you can interact with it.
  3) NetworkManager.InstantiateOwnedObject: Create a prefab object similar to Instantiate method, but this one is locked so that only you can move it (i.e. PUN sharing setting is "Fixed")
  4) NetworkManager.Destroy: Explicitly destroy a managed ASL object. Simple wrapper to call a Destroy on the GameObject if you can interact with it.
  5) NetworkManager.UnrestrictOwnership: Explicitly open up object ownership so anyone can manipulate passed-in object (i.e. PUN sharing setting is "Takeover")
  6) NetworkManager.WhiteListOwnership: Let the passed in players manipulate the passed in object.
  7) NetworkManager.BlackListOwnership: Prevent the passed in players from manipulating the passed in object.
  8) ObjectManager.InstantiateOwnedObject: Create a locked object that only the creator can manipulate (i.e. PUN sharing setting is "Fixed")
  9) ObjectManager.SetObjectRestrictions: Sets who can manipulate an object, or if the object manipulation is restricted at all.
  10) ObjectManager.DestroyHandler: Renamed from DestroyObject to make it clear that it is a helper object.
  11) ObjectManager.RaiseObjectOwnershipRestrictionEventHandler: Raise a PUN event that should be triggered when any kind of ownership attributes of the object changes. Not an implicit method, so it must be explicitly called.
  12) ObjectManager.HandleSyncObjectOwnershipRestriction: Handles an ASL PUN ownership restriction event and sets restrictions for an ASL game object accordingly.
  13) OwnableObject.CanTake: Simple method to determine if ownership of an object can be requested or if the object is free for the user to manipulate.
  14) OwnableObject.Take: Wrapper method to accommodate new ownership restriction capabilities. Also more clearly associates method of grabbing with OwnableObject class instead of having it referenced solely through a string literal in another class (due to PUN RPC setup, this had made it impossible to navigate to the appropriate method easily).
  15) OwnableObject.Restrict: Restrict ownership of the object to whoever is whitelisted for the object (and yourself as well). Returns the list of whitelisted owner IDs (i.e. "lock" an object for just your use).
  16) OwnableObject.RestrictToYourself: Restrict ownership of the object to just yourself, and clear the whitelist of owner IDs.
  17) OwnableObject.UnRestrict: Open up object manipulation of an object to anyone who wants to manipulate it.
  18) OwnableObject.SetRestrictions: Helper method to manually set the restriction level and whitelisted IDs for this game object.
  19) OwnableObject.WhiteListPlayerID: Whitelist the IDs passed so they can manipulate this game object.
  20) OwnableObject.BlackListPlayerID: Blacklist the IDs passed so they can't manipulate this game object.
  21) OwnableObject.ClearOwnablePlayerIDs: Clear up the whitelist for object manipulation.
  22) OwnableObject.IsOwnershipRestricted: Property that says whether the object is "locked" to some users.
  23) OwnableObject.OwnablePlayerIDs: Property that creates a deep copy of the whitelisted player IDs.
  24) OwnableObject.OwnerID: Property that returns the Photon owner ID.
  25) OwnableObject.Owner: Property that returns the Photon owner.
  26) OwnableObject.StoredInScene: Property that says whether the owner of a scene is the null Scene owner.

-- Changed method behavior:
  1) ObjectManager.Instantiate: Photon Network does not have to be connected to create object. Object should be copied over because of scene synchronization.
  2) ObjectManager.HandleRemoteInstantiate (?): Synchronized initial ownership restriction structures between users. Doesn't handle ownership restriction changes, those are handled by the corresponding event.
  3) ObjectManager.InstantiateLocally: Changed return signature to GameObject so that created object can be referenced.
  4) OwnableObject.RelinquishOwnership: Backend logic for transferring ownership of an object to a new player.
  5) ObjectInteractionManager.OnObjectSelected: Changed owner.ID to ownerID in parameter list because a Scene owner is a null Owner object in PUN, causing a null reference exception if trying to reference the owner's ID.

-- Addressed Race Condition:
  1) OwnableObject.Start: Changed to Awake method to avoid race condition that could occur that would provide a null reference for a created object immediately after creation.

-- Added ASL Event Code:
  1) EV_SYNC_OBJECT_OWNERSHIP_RESTRICTION: Used for backend synchronization of ownership restriction (i.e. whitelisting or blacklisting of player IDs that can manipulate an object's position)